### PR TITLE
Added issue templates and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+#### Describe the bug
+A clear and concise description of what the bug is.
+
+#### Describe how to reproduce the bug
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+#### Describe the expected behavior
+A clear and concise description of what you expected to happen.
+
+#### Show some screenshots
+If applicable, add screenshots to help explain your problem.
+
+#### Describe the OS you are using
+ - OS: [e.g. iOS, Ubuntu 18.04, Windows 10, ...]
+ - Browser: [Chrome, Opera. Firefox, ...]
+ - Language: [e.g. C++, Python, ...]
+ - Version [e.g. 3.6.8]
+
+#### Additional context
+Add any other context about the bug here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature request
+assignees: ''
+
+---
+
+#### Describe the feature
+Is your feature request related to a problem with the documentation?
+A clear and concise description of what the problem is. 
+Example: I am always frustrated when [...].
+
+#### Describe the solution you would like
+A clear and concise description of what you want to happen.
+
+#### Describe alternatives you have considered
+A clear and concise description of any alternative solutions or features you have considered.
+
+#### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,37 @@
+---
+name: Question
+about: Ask a question if you do not understand something or just want clarifications.
+title: ''
+labels: question
+assignees: ''
+
+---
+
+#### Describe the problem
+I want to do ... in my application, but what I am actually getting is....
+Here is a screenshot that illustrates the problem:
+
+`image.png`
+
+#### Describe what you have already tried
+This is the most simplified version of my code that I have been able to get, which still produces the problem I described above.
+
+    // my code
+    ...
+
+Basically, what the code is doing is....
+Changing ... does not work because it gives the following error:
+
+
+    Some error
+
+
+#### Describe your research
+[The documentation here] mentioned ... but did not provide a clear example of how that is done.
+[This Stack Overflow question] describes a similar problem, but mine is different because....
+
+#### Ask your question
+So my basic question is, how do I...?
+
+#### Additional context
+Add any other context or screenshots about the question here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+#### Reference to a related issue in the repository
+Add a reference to a related issue in the repository or the OSI organization.
+
+#### Add a description
+Add a description of the changes proposed in the pull request.
+
+**Some questions to ask**:
+What is this change?
+What does it fix?
+Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?
+How has it been tested?
+
+#### Mention a member
+Add @mentions of the person or team responsible for reviewing proposed changes.
+
+#### Check the checklist
+
+- [ ] I have performed a self-review of my own code/documentation.
+- [ ] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
+- [ ] My changes generate no new warnings during the documentation generation.
+- [ ] The existing travis ci which pushes the documentation to gh-pages passes with my changes.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-OSI-Documentation (Work in progress)
+`OSI-Documentation <https://opensimulationinterface.github.io/osi-documentation/>`_ (Work in progress)
 =====================================
 
 .. image:: https://travis-ci.org/OpenSimulationInterface/osi-documentation.svg?branch=master

--- a/osi/commenting.rst
+++ b/osi/commenting.rst
@@ -3,7 +3,7 @@
 Commenting
 ===========
 
-During the building process of open simulation interface (using the `proto2cpp <https://github.com/OpenSimulationInterface/proto2cpp>`_ filter), doxygen is creating a documentation processing all comments written in the code of the interface. In order to do that doxygen needs the comments to be written in a certain way. Please follow these rules to achieve that the documentation is created correctly. You will find further information on doxygen `here <http://www.doxygen.nl/manual/docblocks.html>`_.
+During the building process of open simulation interface (using the `proto2cpp <https://github.com/OpenSimulationInterface/proto2cpp>`_ filter), doxygen is creating a `reference documentation <https://opensimulationinterface.github.io/open-simulation-interface/>`_ processing all comments written in the code of the interface. In order to do that doxygen needs the comments to be written in a certain way. Please follow these rules to achieve that the reference documentation is created correctly. You will find further information on doxygen `here <http://www.doxygen.nl/manual/docblocks.html>`_.
 
 For any additional comment styles see `list <http://www.doxygen.nl/manual/commands.html>`_ of doxygen commands.
 
@@ -246,8 +246,8 @@ Finally you can provide a set of rules which this field needs to be followed. Th
         //
         // \rules
         // is_optional
-        // is_greater_than_or_equal_to: 3
-        // is_less_than_or_equal_to: 10
+        // is_greater_than_or_equal_to: 90000
+        // is_less_than_or_equal_to: 200000
         // \endrules
         //
         optional double atmospheric_pressure = 1;

--- a/osi/howtocontribute.rst
+++ b/osi/howtocontribute.rst
@@ -18,13 +18,12 @@ find with the project on `github <https://github.com/OpenSimulationInterface/ope
 Always make sure to search the existing issues before reporting a new one.
 Issues may be created to discuss:
 
-- Problems
-- Bugs
-- Feature requests
-- Ideas
-- I am sad :( -> please help me :)
+- `Feature requests or Ideas <https://github.com/OpenSimulationInterface/open-simulation-interface/issues/new?assignees=&labels=feature+request&template=feature_request.md&title=>`_
+- `Bugs <https://github.com/OpenSimulationInterface/open-simulation-interface/issues/new?assignees=&labels=bug&template=bug_report.md&title=>`_
+- `Questions <https://github.com/OpenSimulationInterface/open-simulation-interface/issues/new?assignees=&labels=question&template=question.md&title=>`_
+- `Other <https://github.com/OpenSimulationInterface/open-simulation-interface/issues/new>`_
 
-If practicable issues should be closed by a referenced pull request or commit `here <https://help.github.com/en/articles/closing-issues-using-keywords>`_ you can find keywords to close issues automatically).
+If practicable issues should be closed by a referenced pull request or commit (`here <https://help.github.com/en/articles/closing-issues-using-keywords>`_ you can find keywords to close issues automatically). To help developers and maintainers we provide a `pull request template <https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/.github/pull_request_template.md>`_ which will be generated each time you create a new pull request.
 
 First steps
 -----------


### PR DESCRIPTION
#### Reference to a related issue in the repository
This is a general improvement of the documentation which originated from the [issue](https://github.com/OpenSimulationInterface/osi-validation/issues/12) of osi-validation.

#### Add a description
Adding templates for issues and pull requests will reduce the friction and misunderstandings between developers and maintainers. Through a template developers can think in a more detailed way of their feature request, bug or question. The usage of the templates will be now introduced and tested if it will improve the general workflow of the project.

#### Mention a member
@jdsika pls review the issue templates and pull request template for the osi-documentation. If you have further suggestions let me know :).

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [x] My documentation changes are related to another repository in the organization. Here is the link to the [issue](https://github.com/OpenSimulationInterface/osi-validation/issues/12).
- [x] My changes generate no new warnings during the documentation generation.
- [x] The existing travis ci which pushes the documentation to gh-pages passes with my changes.