### PR TITLE
Change OSMP specification reference

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -76,7 +76,7 @@ The authors' vision is to be able to connect any automated driving function to a
     :caption: OSI Sensor Model Packaging:
 
     osi-sensor-model-packaging/README
-    osi-sensor-model-packaging/doc/description
+    osi-sensor-model-packaging/doc/specification
     osi-sensor-model-packaging/doc/examples
 
 .. toctree::


### PR DESCRIPTION
Harmonize OSMP specification document name with PR OpenSimulationInterface/osi-sensor-model-packaging#52.

#### Check the checklist

- [X] I have performed a self-review of my own code/documentation.
- [X] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [X] My changes generate no new warnings during the documentation generation.
- [X] The existing travis ci which pushes the documentation to gh-pages passes with my changes.