### PR TITLE
Fixing dead links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,10 @@ Organization Build Overview
 
 
 
-.. _Open Simulation Interface: https://opensimulationinterface.github.io/osi-documentation/osi/README.html
-.. _OSI Validation: https://opensimulationinterface.github.io/osi-documentation/osi-validator/osivalidator-module.html
+.. _Open Simulation Interface: https://opensimulationinterface.github.io/osi-documentation/open-simulation-interface/README.html
+.. _OSI Validation: https://opensimulationinterface.github.io/osi-documentation/osi-validation/README.html
 .. _OSI Visualizer: https://opensimulationinterface.github.io/osi-documentation/osi-visualizer/README.html
-.. _OSI Model Packaging: https://opensimulationinterface.github.io/osi-documentation/osi-model-packaging/README.html
+.. _OSI Model Packaging: https://opensimulationinterface.github.io/osi-documentation/osi-sensor-model-packaging/README.html
 
 .. |osi_build| image:: https://travis-ci.org/OpenSimulationInterface/open-simulation-interface.svg?branch=master
     :target: https://travis-ci.org/OpenSimulationInterface/open-simulation-interface


### PR DESCRIPTION
#### Reference to a related issue in the repository
Resolves https://github.com/OpenSimulationInterface/osi-documentation/issues/12.

#### Add a description
Fixing dead links detected by users.

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [ ] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [x] My changes generate no new warnings during the documentation generation.
- [x] The existing travis ci which pushes the documentation to gh-pages passes with my changes.