### PR TITLE
21 images of traffic signs missing in documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ script:
     - doxygen
     - cd ../..
     - cp -rf open-simulation-interface/doc/images/* open-simulation-interface/doc/xml/
+    - cp -rf open-simulation-interface/doc/images/BASt_2017/* open-simulation-interface/doc/xml/
 
     # Check spelling mistakes
     # - make spelling


### PR DESCRIPTION
Related issue #21 

#### Fix to missing images in documentation. See issues #21 

The (crude!) fix is just to copy the images again to the folder, where they are referenced from. 
This isn't an elegant fix but since the documentation will be migrated to asciidoc in the near future anyways.

With this change we went from [3636 warnings](https://travis-ci.com/github/OpenSimulationInterface/osi-documentation/jobs/485094630#L11718) to 2033 warnings in the documentation build.
**Note: There might be more things wrong in the build process!**

#### Mention a member
@vkresch 
@pmai 
@jdsika 
@engelben 
Please look at the PR if this is a valid fix. 

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [x] My changes generate no new warnings during the documentation generation.
- [x] The existing travis ci which pushes the documentation to gh-pages passes with my changes.