### PR TITLE
Added configuration for new custom bibtex support.

### DIFF
--- a/.antora/antora.yml
+++ b/.antora/antora.yml
@@ -35,6 +35,7 @@ asciidoc: # Sets global AsciiDoc attributes that are applied for every page of t
     doc_open_simulation_interface: 'interface:'
     doc_osi-sensor-model-packaging: 'sensor-model:'
     page-repository-links: [["https://github.com/OpenSimulationInterface/open-simulation-interface", "Open Simulation Interface"],["https://github.com/OpenSimulationInterface/osi-sensor-model-packaging","OSI Sensor Model Packaging"],["https://github.com/OpenSimulationInterface/osi-validation","OSI Validation"]]
+    asamBibliography: 'specification:general_docs/bibliography.bib'
 
   # END - Mandatory ASAM attributes
   # doxygen_interface_version: "v3.2.0"  # The interface version that needs to be retrieved


### PR DESCRIPTION
This adds the necessary configuration to the antora.yml so that the custom ASAM bibtex extension for Antora can generate and link to the bibliography entries correctly. Note: This also requires a setup change in the generator which is pushed separately.

Signed-off-by: Philip Windecker <philip.windecker@avenyr.de>

#### Reference to a related issue in the repository
There is no issue here but in the internal ASAM GitLab. 

#### Add a description
Antora does not support bibtex. The bibtex solution for Asciidoctor was developed in Ruby and is not compatible with Antora (which is JavaScript). Additionally, the Asciidoctor solution expects all content to be within the same file. However, Antora distributes content over multiple separate pages which Asciidoctor (used by Antora to generate each page) does not know about.
Therefore, the existing solution cannot be used.

ASAM has developed its own rudimentary solution for Antora that supports a limited set of features from bibtex (those that were used previously in ASAM Simulation domain projects such as this). This solution specifically works with Antora and distributed pages while still utilizing the available bibtex file, thus keeping everything compatible with Asciidoctor.

To activate this extension, however, the project must add a bit of configuration to its setup, mainly the site.yml (activating the extension itself) and the relevant antora.yml (setting the location of the bibliography file).

This PR deals with the latter while the former has been changed directly in generator repository.

#### Mention a member
 @pmai 

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [ ] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [x] My changes generate no new warnings during the documentation generation.
- [x] The existing travis ci which pushes the documentation to gh-pages passes with my changes.