### PR TITLE
Antora/improve local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vpython/
 _build/
 .vscode/
 _templates/
+local_build_tools/*.html

--- a/content/_config.adoc
+++ b/content/_config.adoc
@@ -36,7 +36,7 @@ ifndef::include-only-once[]
 // :images_osi-sensor-model-packaging: ../../osi-sensor-model-packaging/doc/images
 :doc_open_simulation_interface: open-simulation-interface/doc/
 :doc_osi-sensor-model-packaging: osi-sensor-model-packaging/doc/
-:images_open_simulation_interface: ../../open-simulation-interface/doc/images
+:images_open_simulation_interface: images
 // Since a document spanning multiple repos is rendered here, the pathing regarding images is a bit involved.
 // We create a variable for every repo that is included. It point to the repo in question.
 // If the subrepo is rendered seperatly, then the variable is set to just "./images" with ifdef.

--- a/content/_config.adoc
+++ b/content/_config.adoc
@@ -58,6 +58,6 @@ endif::[]
 ifdef::local[]
 :doc_open_simulation_interface: ../../open-simulation-interface/doc/
 :doc_osi-sensor-model-packaging: ../../osi-sensor-model-packaging/doc/
-:images_open_simulation_interface: ./images
+:images_open_simulation_interface: ../images
 :data-uri:
 endif::[]

--- a/content/_config.adoc
+++ b/content/_config.adoc
@@ -54,3 +54,10 @@ endif::[]
 ifdef::env-gitlab[]
 :relfilesuffix: .adoc
 endif::[]
+
+ifdef::local[]
+:doc_open_simulation_interface: ../../open-simulation-interface/doc/
+:doc_osi-sensor-model-packaging: ../../osi-sensor-model-packaging/doc/
+:images_open_simulation_interface: ./images
+:data-uri:
+endif::[]

--- a/content/_config.adoc
+++ b/content/_config.adoc
@@ -36,7 +36,7 @@ ifndef::include-only-once[]
 // :images_osi-sensor-model-packaging: ../../osi-sensor-model-packaging/doc/images
 :doc_open_simulation_interface: open-simulation-interface/doc/
 :doc_osi-sensor-model-packaging: osi-sensor-model-packaging/doc/
-:images_open_simulation_interface: images
+:images_open_simulation_interface: ../images
 // Since a document spanning multiple repos is rendered here, the pathing regarding images is a bit involved.
 // We create a variable for every repo that is included. It point to the repo in question.
 // If the subrepo is rendered seperatly, then the variable is set to just "./images" with ifdef.

--- a/content/index.adoc
+++ b/content/index.adoc
@@ -43,11 +43,13 @@ include::./general_docs/versioning.adoc[leveloffset=+2]
 include::./general_standard/relations_to_other_standards.adoc[leveloffset=+2]
 
 // START: including the documentation of other osi repositories
-
+:imagesdir: {doc_open_simulation_interface}images
 include::{doc_open_simulation_interface}open-simulation-interface_user_guide.adoc[leveloffset=+1]
 
+:imagesdir: {doc_osi-sensor-model-packaging}images
 include::{doc_osi-sensor-model-packaging}osi-sensor-model-packaging_spec.adoc[leveloffset=+1]
 
+:imagesdir: ./images
 // osi-validation and osi-visualizer are considered supplementary tooling that is not normative. They are therefore not part of the ASAM standard release.
 // include::./osi-validation/doc/osi-validator_user_guide.adoc[leveloffset=+1,opts=optional]
 

--- a/local_build_tools/compose.yml
+++ b/local_build_tools/compose.yml
@@ -5,4 +5,6 @@ services:
     image: asciidoctor/docker-asciidoctor
     volumes:
       - ../:/documents
-    entrypoint: asciidoctor --failure-level WARN -r asciidoctor-kroki -a mathjax -r asciidoctor-bibtex --trace content/index.adoc -o local_build_tools/HTML_content_local_build.html
+      - ../../open-simulation-interface:/open-simulation-interface
+      - ../../osi-sensor-model-packaging:/osi-sensor-model-packaging
+    entrypoint: asciidoctor -a local=true --failure-level WARN -r asciidoctor-kroki -a mathjax -r asciidoctor-bibtex --trace content/index.adoc -o local_build_tools/HTML_content_local_build.html


### PR DESCRIPTION
#### Reference to a related issue in the repository
No issue available.

#### Add a description
Makes local previews better and easier with Asciidoctor while keeping Antora compatibility.

#### Mention a member
@pmai 

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [ ] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [x] My changes generate no new warnings during the documentation generation.
- [ ] The existing travis ci which pushes the documentation to gh-pages passes with my changes.