### PR TITLE
Changed ruleset for Enum types.

### DIFF
--- a/content/contributing/naming_conventions.adoc
+++ b/content/contributing/naming_conventions.adoc
@@ -41,10 +41,12 @@ message EnvironmentalConditions
 }
 ----
 
-Enum field names shall use _UPPER_SNAKE_CASE_.
-Enum fields shall always be prefixed with the name of the corresponding enum.
-The first enum field should always use the suffix _UNKNOWN_.
-The second enum field should always use the suffix _OTHER_.
+Enum field value names shall use _UPPER_SNAKE_CASE_.
+Enum field value names shall always be prefixed with the name of the corresponding enum.
+
+For enum fields that are concerned with ground truth or sensor data, the first two enum values shall always be defined with the following rules:
+The first enum field value shall always use the suffix _UNKNOWN_.
+The second enum field value shall always use the suffix _OTHER_.
 
 [source,protobuf,linenums]
 ----
@@ -62,3 +64,5 @@ message EnvironmentalConditions
     }
 }
 ----
+
+Other enum fields, especially purely technical fields, can deviate from the rules for the first two field values.

--- a/content/contributing/naming_conventions.adoc
+++ b/content/contributing/naming_conventions.adoc
@@ -43,8 +43,8 @@ message EnvironmentalConditions
 
 Enum field names shall use _UPPER_SNAKE_CASE_.
 Enum fields shall always be prefixed with the name of the corresponding enum.
-The first enum field shall always use the suffix _UNKNOWN_.
-The second enum field shall always use the suffix _OTHER_.
+The first enum field should always use the suffix _UNKNOWN_.
+The second enum field should always use the suffix _OTHER_.
 
 [source,protobuf,linenums]
 ----


### PR DESCRIPTION
The ruleset for enum definition "shall" is not useful in many cases where "_UNKNOWN_" and "_OTHER_" is more confusing than helpful. So  it should only be a recommendation for future implmentations.

#### Reference to a related issue in the repository
There are already multiple enums without the UNKNOWN and OTHER definition, like in [https://github.com/OpenSimulationInterface/open-simulation-interface/blob/master/osi_motionrequest.proto](url). There are also current PRs where the current definition is appropriate.

#### Add a description
The rule to add "_UNKNOWN_" and "_OTHER_" should only be a recommendation in the future.

#### Mention a member
@thempen 

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [x] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [x] My changes generate no new warnings during the documentation generation.
- [x] The existing travis ci which pushes the documentation to gh-pages passes with my changes.