### PR TITLE
Add bibliography for coordinate rotation docs

### DIFF
--- a/content/general_docs/bibliography.bib
+++ b/content/general_docs/bibliography.bib
@@ -65,5 +65,17 @@
   year = {2020}
 }
 
+@misc{tait_bryan_convention,
+  author = {{Wikipedia}},
+  title  = {https://en.wikipedia.org/wiki/Euler_angles#Conventions[Euler Angles - Conventions^]},
+  note   = {[viewed 2025-07]}
+}
+
+@misc{euler_to_quaternion,
+  author = {{Wikipedia}},
+  title  = {https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions#Euler_angles_(z-y%E2%80%B2-x%E2%80%B3_intrinsic)_%E2%86%92_quaternion[Rotation formalisms in three dimensions — Euler angles (z-y′-x″ intrinsic) → quaternion^]},
+  note   = {[viewed 2025-07]}
+}
+
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
This PR is related to https://github.com/OpenSimulationInterface/open-simulation-interface/pull/850 and adds the required bibliography references in the same format as other online references.