### PR TITLE
cleanup mentioned repos

### DIFF
--- a/.antora/antora.yml
+++ b/.antora/antora.yml
@@ -35,7 +35,13 @@ asciidoc: # Sets global AsciiDoc attributes that are applied for every page of t
     images_open_simulation_interface: 'interface:'
     doc_open_simulation_interface: 'interface:'
     doc_osi-sensor-model-packaging: 'sensor-model:'
-    page-repository-links: [["https://github.com/OpenSimulationInterface/open-simulation-interface", "Open Simulation Interface"],["https://github.com/OpenSimulationInterface/osi-sensor-model-packaging","OSI Sensor Model Packaging"],["https://github.com/OpenSimulationInterface/osi-validation","OSI Validation"]]
+    page-repository-links:
+      - ["https://github.com/OpenSimulationInterface/open-simulation-interface", "Open Simulation Interface"]
+      - ["https://github.com/OpenSimulationInterface/osi-sensor-model-packaging", "OSI Sensor Model Packaging"]
+      - ["https://github.com/OpenSimulationInterface/osi-cpp", "OSI cpp"]
+      - ["https://github.com/OpenSimulationInterface/osi-python", "OSI python"]
+      - ["https://github.com/OpenSimulationInterface/qc-osi-trace", "OSI Trace Checker"]
+
     asamBibliography: 'specification:general_docs/bibliography.bib'
 
   # END - Mandatory ASAM attributes

--- a/content/general_docs/osi_repos.adoc
+++ b/content/general_docs/osi_repos.adoc
@@ -10,15 +10,39 @@ OSI and its supporting tools are developed publicly on GitHub.
 
 The source code and documentation for OSI and OSI-related tools are spread over several repositories:
 
+
+== Interface and Specifications
+
 https://github.com/OpenSimulationInterface/open-simulation-interface[open-simulation-interface]::
-Main repository containing the interface description based on Google's Protocol Buffers, including helper scripts and test scripts.
-Hosts the .proto files.
+Main repository containing the interface description based on Google's Protocol Buffers. Hosts the .proto files.
 
-https://github.com/OpenSimulationInterface/osi-documentation[osi-documentation]:: Source for the AsciiDoc files used to compile the general chapters of the OSI documentation.
+https://github.com/OpenSimulationInterface/osi-sensor-model-packaging[osi-sensor-model-packaging]:: 
+Packaging specification for OSI models used in FMI 2.0 cite:[fmi2.0] simulation environments, including examples.
 
-https://github.com/OpenSimulationInterface/osi-sensor-model-packaging[osi-sensor-model-packaging]:: Packaging specification for OSI models used in FMI 2.0 cite:[fmi2.0] simulation environments, including examples.
 
-https://github.com/OpenSimulationInterface/proto2cpp[proto2cpp]:: Doxygen filter for creating the reference documentation from OSI .proto files.
+== Language Bindings
 
-https://github.com/OpenSimulationInterface/osi-antora-generator[osi-antora-generator]:: Contains the Antora generator and the relevant pipeline.
+https://github.com/OpenSimulationInterface/osi-cpp[osi-cpp]::
+C\++ bindings for OSI. Provides generated C++ classes for working with OSI data structures defined in the `.proto` files.
+
+https://github.com/OpenSimulationInterface/osi-python[osi-python]::
+Python bindings for OSI. Provides generated Python classes as well as utility modules for reading OSI trace files.
+
+
+== Tools and Utilities
+
+https://github.com/OpenSimulationInterface/qc-osi-trace[qc-osi-trace]:: 
+A OSI trace files quality checker as part of the https://github.com/asam-ev/qc-framework[ASAM Quality Checker] project.
+
+
+== Documentation and Generation Infrastructure
+
+https://github.com/OpenSimulationInterface/osi-documentation[osi-documentation]:: 
+Source for the AsciiDoc files used to compile the general chapters of the OSI documentation.
+
+https://github.com/OpenSimulationInterface/proto2cpp[proto2cpp]:: 
+Doxygen filter for creating the reference documentation from OSI .proto files.
+
+https://github.com/OpenSimulationInterface/osi-antora-generator[osi-antora-generator]:: 
+Contains the Antora generator and the relevant pipeline.
 This repository is responsible for both building and hosting the https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/specification/index.html/[{THIS_STANDARD} Specification^] as well as the https://opensimulationinterface.github.io/osi-antora-generator/asamosi/latest/gen/index.html[{THIS_STANDARD} Reference Documentation^].

--- a/content/index.adoc
+++ b/content/index.adoc
@@ -50,13 +50,6 @@ include::{doc_open_simulation_interface}open-simulation-interface_user_guide.ado
 include::{doc_osi-sensor-model-packaging}osi-sensor-model-packaging_spec.adoc[leveloffset=+1]
 
 :imagesdir: ./images
-// osi-validation and osi-visualizer are considered supplementary tooling that is not normative. They are therefore not part of the ASAM standard release.
-// include::./osi-validation/doc/osi-validator_user_guide.adoc[leveloffset=+1,opts=optional]
-
-// include::./osi-visualizer/doc/osi-visualizer_user_guide.adoc[leveloffset=+1,opts=optional]
-
-// proto2cpp is an tooling that is internally used to create the DOXYGEN documentation. It doc shall not the part of the OSI specification.
-// include::./proto2cpp/doc/proto2ccp_user_guide.adoc[leveloffset=+1]
 
 // END: including the documentation of other osi repositories
 


### PR DESCRIPTION
#### Reference to a related issue in the repository
https://github.com/OpenSimulationInterface/osi-documentation/issues/84

#### Add a description
- Removed osi validation
- Restructured the overview into sections
- Added osi-cpp and osi-python
- Added all except the documentation repos to the menu bar dropdown (the thing in the top right)
- Removed old comments

#### Check the checklist

- [x] I have performed a self-review of my own code/documentation.
- [x] My documentation changes are related to another repository in the organization. Here is the link to the issue/repo.
- [x] My changes generate no new warnings during the documentation generation.
- [x] The Antora pipeline which pushes the documentation to gh-pages on the downstream repository passes with my changes.